### PR TITLE
fix: Fix cross-compiling arguments of secp256k1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CC := riscv64-unknown-elf-gcc
 DUMP := riscv64-unknown-elf-objdump
+HOST := riscv64-elf
 CFLAGS := -Ideps/secp256k1/src -Ideps/secp256k1 -O3
 LDFLAGS := -Wl,-static -fdata-sections -ffunction-sections -Wl,--gc-sections -Wl,-s
 SECP256K1_LIB := deps/secp256k1/src/ecmult_static_pre_context.h
@@ -18,7 +19,7 @@ build/schnorr_bench: c/schnorr_bench.c c/sha3.h $(SECP256K1_LIB)
 $(SECP256K1_LIB):
 	cd deps/secp256k1 && \
 		./autogen.sh && \
-		CC=riscv64-unknown-elf-gcc LD=riscv64-unknown-elf-gcc ./configure --with-bignum=no --enable-ecmult-static-precomputation --enable-endomorphism --enable-module-recovery --enable-module-extrakeys --enable-module-schnorrsig --enable-experimental --host=riscv64-elf && \
+		CC=$(CC) LD=$(CC) ./configure --with-bignum=no --enable-ecmult-static-precomputation --enable-endomorphism --enable-module-recovery --enable-module-extrakeys --enable-module-schnorrsig --enable-experimental --host=$(HOST) && \
 		make
 
 clean:


### PR DESCRIPTION
Starting from macOS Bigsur at least(there might be issues in earlier version but we haven't tested yet), the current arguments used to cross-compile secp256k1 would fail on a native toolchain on macOS. This commit fixes the code with proper arguments, so we can now use the following commands to compile this repo on macOS:

```
make CC=riscv64-ckb-elf-gcc DUMP=riscv64-ckb-elf-objdump HOST=riscv64-ckb-elf
```

The commit also leaves the original values untouched for compatibility reasons.